### PR TITLE
fix(typescript): remove I from interfaces

### DIFF
--- a/react-native/typescript.md
+++ b/react-native/typescript.md
@@ -16,7 +16,7 @@
 | Category         | Style           |
 | ------------- |:-------------:|
 | class     | UpperCamelCase |
-| interface | **I**UpperCamelCase |
+| interface | UpperCamelCase |
 | type      | UpperCamelCase |
 | enum      | UpperCamelCase |
 | variable  | lowerCamelCase |
@@ -28,7 +28,7 @@
 | global constant values  | CONSTANT_CASE |
 | static readonly values  | CONSTANT_CASE |
 
-* Do not use `_` or other prefixes unless it's `I` for interfaces.
+* Do not use `_` or other prefixes.
 * Generics parameters like `Array<T>` should use a single uppercase character.
 
 ## Formatting


### PR DESCRIPTION
Предлагаю убрать `I` из имени интерфейса.

Бывают ситуации, когда у нас был интерфейс, например
```
interface IHttpResponse<Data> {
  data?: Data;
  error?: Error;
  status: number;
}
```

И хочу разделить success и error на 2 интерфейса
```
interface IHttpResponseSuccess<Data> {
  data: Data;
  status: 200;
}

interface IHttpResponseError {
  error: Error;
  status: 400 | 500;
}

type HttpResponse<Data> = IHttpResponseSuccess<Data> | IHttpResponseError;
```

в таком случае `HttpResponse` перестает быть интерфейсом и становится юнион типом. Получается, что надо все в прилаге будет переименовать с `IHttpResponse` в `HttpResponse`.

Я после пары похожих кейсов, когда надо было интерфейс переделать в тип или наборот, отказался от префикса в имени интерфейса.

Вот еще есть пример почему префикс это плохая идея

> Reason: Unconventional. `lib.d.ts` defines important interfaces without an I (e.g. Window, Document etc).

https://github.com/basarat/typescript-book/blob/master/docs/styleguide/styleguide.md#interface