### PR TITLE
feat: add deprecation rule

### DIFF
--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -73,10 +73,15 @@ const rules = {
       next: 'import'
     }
   ],
+  'deprecation/deprecation': 'warn',
 }
 
 module.exports = {
   rules,
+  plugins: [
+    // npm i -D eslint-plugin-deprecation
+    'deprecation',
+  ],
   extends: [
     'eslint:recommended',
   ],


### PR DESCRIPTION
При обновлении зависимостей может меняться апи, и какие-то вещи могут становится deprecated. Не все и всегда читают ченжлоги. Это правило поможет узнавать про deprecation.

Кидать ошибки линтера и ломать ci или git hook'и не очень, поэтому error тут не подойдет. Для более плавного избавления от deprecated функции лучше использовать warn.

TODO: Надо обновить наш текстовый стайлгайд, но я пока не оч понял куда это правильнее вписать. @malashkevich подскажешь?