### PR TITLE
fix(rxjs): fix typo in decorator name for angular services

### DIFF
--- a/rxjs/rxjs-angular.eslintrc
+++ b/rxjs/rxjs-angular.eslintrc
@@ -9,7 +9,7 @@
     "rxjs-angular/prefer-takeuntil":[
       "error",
       {
-        "checkDecorators": ["Component", "Directive", "Pipe", "Service"],
+        "checkDecorators": ["Component", "Directive", "Pipe", "Injectable"],
         "checkDestroy": false
       }
     ]


### PR DESCRIPTION
There is no `Service` decorator 🤷. The decorator for angular services or any other DI things is called `Injectable`.