### PR TITLE
create modules to export by npm-package

### DIFF
--- a/angular.js
+++ b/angular.js
@@ -1,0 +1,16 @@
+module.exports = {
+	extends: [
+
+	],
+	overrides: [
+		{
+			files: ['*.ts'],
+			extends: ['./rules/typescript', './rxjs', './angular/angular.eslintrc']
+		},
+		{
+			files: ['*.html'],
+			extends: ['./angular/angular-template.eslintrc']
+		},
+	],
+	rules: {},
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "eslint-config-akveo",
+  "version": "1.0.0",
+  "description": "Akveo's ESLint config based on styleguide",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./angular": "./angular.js",
+    "./react": "./react.js",
+    "./react-native": "./react-native.js",
+    "./rxjs": "./rxjs.js",
+    "./rules/javascript": "./rules/javascript.js",
+    "./rules/typescript": "./rules/typescript.js",
+    "./package.json": "./package.json"
+  },
+  "keywords": [
+    "style guide",
+    "lint",
+    "akveo",
+    "angular",
+    "typescript",
+    "rxjs",
+    "react",
+    "react-native",
+    "java",
+    "es6",
+    "es2015",
+    "es2016",
+    "es2017",
+    "es2018"
+  ],
+  "peerDependencies": {
+    "eslint": "^8.15.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akveo/styleguide.git"
+  },
+  "author": "akveo <contact@akveo.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/akveo/styleguide/issues"
+  },
+  "homepage": "https://github.com/akveo/styleguide#readme"
+}

--- a/react-native.js
+++ b/react-native.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: [
+		'./rules/javascript',
+		'./rules/react-native',
+	].map(require.resolve),
+	rules: {}
+};

--- a/react.js
+++ b/react.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: [
+		'./rules/javascript',
+		'./rules/react',
+	].map(require.resolve),
+	rules: {}
+};

--- a/rxjs.js
+++ b/rxjs.js
@@ -1,0 +1,8 @@
+module.exports = {
+	extends: [
+		'./rxjs/rxjs.eslintrc',
+		'./rxjs/rxjs-angular.eslintrc',
+		'./rxjs/rxjs-with-store.eslintrc',
+	].map(require.resolve),
+	rules: {}
+};


### PR DESCRIPTION
How to use:
Add  to your .eslintrc
```
{
  "extends": [ "akveo/angular"],  // choose the name of the module / modules from exports in package.json
  "parserOptions": {
    "project": ["./tsconfig.json"]
  }
}
```